### PR TITLE
Route Extractions

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,5 +48,4 @@ curl localhost:3000/faux -> No route found for /faux
 ```
 
 Possible feature additions:
-- Add capture groups for path extractions
 - Add HTTP verb capabilities and checks


### PR DESCRIPTION
This PR adds in route extraction using capture groups. Since this functionality isn't a part of `RegexSet` it needs to use a single compiled regular expression that matches the route.
