### PR TITLE
Publicly export RouterError for use outside crate

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -8,7 +8,7 @@ use hyper::server::{Handler, Request, Response};
 use hyper::status::StatusCode;
 use regex::{Regex, RegexSet};
 
-use error::RouterError;
+pub use error::RouterError;
 
 pub type Captures = Option<Vec<String>>;
 pub type NotFoundFn = fn(Request, Response);


### PR DESCRIPTION
I think this ought to be exposed to allow crate users to handle errors correctly.
