### PR TITLE
Handle overlapping routes with different Regexes

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ license = "MIT"
 
 [dependencies]
 hyper = { version = "0.9", default-features = false }
-regex = "0.1"
+regex = "0.1.59"
 
 [features]
 default = ["ssl"]

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,26 +1,30 @@
 use std::{error, fmt};
+use regex;
 
 // Potential errors that can happen while constructing a router.
-#[derive(Debug, PartialEq)]
-pub enum RouterError {
-    TooFewRoutes,
-    BadSet,
+#[derive(Debug)]
+pub enum Error {
+    BadRegex(regex::Error),
 }
 
-impl error::Error for RouterError {
+impl From<regex::Error> for Error {
+    fn from(error: regex::Error) -> Error {
+        Error::BadRegex(error)
+    }
+}
+
+impl error::Error for Error {
     fn description(&self) -> &str {
         match *self {
-            RouterError::TooFewRoutes => "No routes provided for the router",
-            RouterError::BadSet => "Error making RegexSet",
+            Error::BadRegex(ref error) => error.description(),
         }
     }
 }
 
-impl fmt::Display for RouterError {
+impl fmt::Display for Error {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         match *self {
-            RouterError::TooFewRoutes => write!(f, "Cannot make a router with zero routes."),
-            RouterError::BadSet => write!(f, "Error making RegexSet."),
+            Error::BadRegex(ref error) => write!(f, "{}", error),
         }
     }
 }

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,14 +1,13 @@
 use std::{error, fmt};
-use regex;
 
 // Potential errors that can happen while constructing a router.
 #[derive(Debug)]
 pub enum Error {
-    BadRegex(regex::Error),
+    BadRegex(::regex::Error),
 }
 
-impl From<regex::Error> for Error {
-    fn from(error: regex::Error) -> Error {
+impl From<::regex::Error> for Error {
+    fn from(error: ::regex::Error) -> Error {
         Error::BadRegex(error)
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -53,6 +53,8 @@ impl Handler for Router {
     }
 }
 
+/// A `RouterBuilder` enables you to build up a set of routes and their handlers
+/// to be handled by a `Router`.
 pub struct RouterBuilder {
     routes: Vec<String>,
     handlers: Vec<(Method, RouteHandler)>,
@@ -60,6 +62,7 @@ pub struct RouterBuilder {
 }
 
 impl RouterBuilder {
+    /// Create a new `RouterBuilder` with no route handlers.
     pub fn new() -> RouterBuilder {
         RouterBuilder {
             routes: vec![],
@@ -68,6 +71,9 @@ impl RouterBuilder {
         }
     }
 
+    /// Install a handler for requests of method `verb` and which have paths
+    /// matching `route`. There are also convenience methods named after the
+    /// appropriate verb.
     pub fn route<H>(&mut self, verb: Method, route: &str, handler: H) -> &mut RouterBuilder where
         H: Fn(Request, Response, Captures) + Send + Sync + 'static
     {
@@ -80,6 +86,8 @@ impl RouterBuilder {
         self
     }
 
+    /// Compile the routes in a `RouterBuilder` to produce a `Router` capable
+    /// of handling Hyper requests.
     pub fn finalize(self) -> Result<Router, Error> {
         Ok(Router {
             routes: RegexSet::new(self.routes.iter())?,
@@ -89,42 +97,51 @@ impl RouterBuilder {
         })
     }
 
+    /// Convenience method to install a GET handler.
     pub fn get<H>(&mut self, route: &str, handler: H) -> &mut RouterBuilder where 
         H: Fn(Request, Response, Captures) + Send + Sync + 'static
     {
         self.route(Method::Get, route, handler)
     }
 
+    /// Convenience method to install a POST handler.
     pub fn post<H>(&mut self, route: &str, handler: H) -> &mut RouterBuilder where 
         H: Fn(Request, Response, Captures) + Send + Sync + 'static
     {
         self.route(Method::Post, route, handler)
     }
 
+    /// Convenience method to install a PUT handler.
     pub fn put<H>(&mut self, route: &str, handler: H) -> &mut RouterBuilder where 
         H: Fn(Request, Response, Captures) + Send + Sync + 'static
     {
         self.route(Method::Put, route, handler)
     }
 
+    /// Convenience method to install a PATCH handler.
     pub fn patch<H>(&mut self, route: &str, handler: H) -> &mut RouterBuilder where 
         H: Fn(Request, Response, Captures) + Send + Sync + 'static
     {
         self.route(Method::Patch, route, handler)
     }
 
+    /// Convenience method to install a DELETE handler.
     pub fn delete<H>(&mut self, route: &str, handler: H) -> &mut RouterBuilder where 
         H: Fn(Request, Response, Captures) + Send + Sync + 'static
     {
         self.route(Method::Delete, route, handler)
     }
 
+    /// Convenience method to install an OPTIONS handler.
     pub fn options<H>(&mut self, route: &str, handler: H) -> &mut RouterBuilder where 
         H: Fn(Request, Response, Captures) + Send + Sync + 'static
     {
         self.route(Method::Options, route, handler)
     }
 
+    /// Install a fallback handler for when there is no matching route for a
+    /// request. If none is installed, the resulting `Router` will use a
+    /// default handler.
     pub fn not_found<H>(&mut self, not_found: H) -> &mut RouterBuilder where
         H: Fn(Request, Response, Captures) + Send + Sync + 'static
     {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,23 +1,17 @@
 extern crate hyper;
 extern crate regex;
 
-use std::collections::HashMap;
-
 use hyper::method::Method;
 use hyper::server::{Handler, Request, Response};
 use hyper::status::StatusCode;
 use regex::{Regex, RegexSet};
 
-pub use error::RouterError;
+pub use error::Error;
+
+mod error;
 
 pub type Captures = Option<Vec<String>>;
-pub type NotFoundFn = fn(Request, Response);
-
-#[derive(PartialEq, Eq, Hash)]
-pub struct RouteInfo {
-    route: String,
-    verb: Method,
-}
+type RouteHandler = Box<Fn(Request, Response, Captures) + Send + Sync>;
 
 /// The Router struct contains the information for your app to route requests
 /// properly based on their HTTP method and matching route. It allows the use
@@ -27,173 +21,120 @@ pub struct RouteInfo {
 /// instance of the hyper server. Because of this, it has the potential to match
 /// multiple patterns that you provide. It will call the first handler that it
 /// matches against so the order in which you add routes matters.
-#[derive(Default)]
 pub struct Router {
-    /// A custom 404 handler that you can provide.
-    pub not_found: Option<NotFoundFn>,
-
-    routes: Option<RegexSet>,
-    route_list: Vec<String>,
-    compiled_list: Vec<Regex>,
-    route_map: HashMap<RouteInfo, Box<Fn(Request, Response, Captures)>>,
+    routes: RegexSet,
+    regexes: Vec<Regex>,
+    handlers: Vec<(Method, RouteHandler)>,
+    not_found: RouteHandler,
 }
-
-// These are needed to satisfy the Handler trait while using Fn to accept closures.
-unsafe impl Send for Router {}
-unsafe impl Sync for Router {}
 
 impl Handler for Router {
-    // The handle method for the router simply tries to match the URI against
-    // the first pattern that it can which in turn calls its associated handle
-    // function passing the hyper Request and Response structures.
     fn handle(&self, req: Request, res: Response) {
         let uri = format!("{}", req.uri);
-        let matches = self.routes.as_ref().unwrap().matches(&uri);
-        let index = matches.iter().next();
-        match index {
-            Some(i) => {
-                let route = &self.route_list[i];
-                let route_info = RouteInfo {
-                    route: route.clone(),
-                    verb: req.method.clone(),
-                };
-                let handler = self.route_map.get(&route_info);
-                match handler {
-                    Some(h) => {
-                        let compiled_pattern = &self.compiled_list[i];
-                        let captures = get_captures(compiled_pattern, &uri);
-                        h(req, res, captures);
-                    }
-                    None => {
-                        not_allowed(req, res);
-                    }
-                }
-            }
-            None => self.not_found.unwrap()(req, res),
+        let matches = self.routes.matches(&uri);
+        if !matches.matched_any() {
+            (self.not_found)(req, res, None);
+            return;
         }
+
+        for index in matches {
+            let (ref method, ref handler) = self.handlers[index];
+            if method != &req.method {
+                continue;
+            }
+
+            let ref regex = self.regexes[index];
+            let captures = get_captures(regex, &uri);
+            handler(req, res, captures);
+            return;
+        }
+
+        not_allowed(req, res);
     }
 }
 
-impl Router {
-    /// Construct a new Router to maintain the routes and their handler
-    /// functions.
-    pub fn new() -> Router {
-        Router {
+pub struct RouterBuilder {
+    routes: Vec<String>,
+    handlers: Vec<(Method, RouteHandler)>,
+    not_found: Option<RouteHandler>,
+}
+
+impl RouterBuilder {
+    pub fn new() -> RouterBuilder {
+        RouterBuilder {
+            routes: vec![],
+            handlers: vec![],
             not_found: None,
-            routes: None,
-            route_list: Vec::new(),
-            compiled_list: Vec::new(),
-            route_map: HashMap::new(),
         }
     }
 
-    /// Add a route to the router and give it a function to call when the route
-    /// is matched against. You can call this explicitly or use the convenience
-    /// methods defined below.
-    pub fn add_route<H>(&mut self, verb: Method, route: &str, handler: H)
-        where H: Fn(Request, Response, Captures) + Send + Sync + 'static
+    pub fn route<H>(&mut self, verb: Method, route: &str, handler: H) -> &mut RouterBuilder where
+        H: Fn(Request, Response, Captures) + Send + Sync + 'static
     {
-        // This is added to provide stricter matching for routes that could have more than one
-        // match.
-        let anchored_pattern = [r"\A", route].join("");
-        let route_info = RouteInfo {
-            route: anchored_pattern.clone(),
-            verb: verb,
-        };
-        let pattern = Regex::new(&anchored_pattern);
-        match pattern {
-            Ok(p) => {
-                self.compiled_list.push(p);
-            }
-            Err(e) => {
-                println!("Not adding this route due to error: {}", e);
-            }
-        }
-        self.route_list.push(anchored_pattern.clone());
-        self.route_map.insert(route_info, Box::new(handler));
+        // anchor at the start and end so routes only match exactly
+        let pattern = [r"\A", route, r"\z"].join("");
+
+        self.routes.push(pattern);
+        self.handlers.push((verb, Box::new(handler)));
+
+        self
     }
 
+    pub fn finalize(self) -> Result<Router, Error> {
+        Ok(Router {
+            routes: RegexSet::new(self.routes.iter())?,
+            regexes: self.routes.iter().map(|route| Regex::new(route)).collect::<Result<_, _>>()?,
+            handlers: self.handlers,
+            not_found: self.not_found.unwrap_or_else(|| Box::new(default_not_found)),
+        })
+    }
 
-    /// A convenience method for OPTIONS requests.
-    pub fn options<H>(&mut self, route: &str, handler: H)
-        where H: Fn(Request, Response, Captures) + Send + Sync + 'static
+    pub fn get<H>(&mut self, route: &str, handler: H) -> &mut RouterBuilder where 
+        H: Fn(Request, Response, Captures) + Send + Sync + 'static
     {
-        self.add_route(Method::Options, route, handler);
+        self.route(Method::Get, route, handler)
     }
 
-    /// A convenience method for GET requests.
-    pub fn get<H>(&mut self, route: &str, handler: H)
-        where H: Fn(Request, Response, Captures) + Send + Sync + 'static
+    pub fn post<H>(&mut self, route: &str, handler: H) -> &mut RouterBuilder where 
+        H: Fn(Request, Response, Captures) + Send + Sync + 'static
     {
-        self.add_route(Method::Get, route, handler);
+        self.route(Method::Post, route, handler)
     }
 
-    /// A convenience method for POST requests.
-    pub fn post<H>(&mut self, route: &str, handler: H)
-        where H: Fn(Request, Response, Captures) + Send + Sync + 'static
+    pub fn put<H>(&mut self, route: &str, handler: H) -> &mut RouterBuilder where 
+        H: Fn(Request, Response, Captures) + Send + Sync + 'static
     {
-        self.add_route(Method::Post, route, handler);
+        self.route(Method::Put, route, handler)
     }
 
-    /// A convenience method for PUT requests.
-    pub fn put<H>(&mut self, route: &str, handler: H)
-        where H: Fn(Request, Response, Captures) + Send + Sync + 'static
+    pub fn patch<H>(&mut self, route: &str, handler: H) -> &mut RouterBuilder where 
+        H: Fn(Request, Response, Captures) + Send + Sync + 'static
     {
-        self.add_route(Method::Put, route, handler);
+        self.route(Method::Patch, route, handler)
     }
 
-    /// A convenience method for DELETE requests.
-    pub fn delete<H>(&mut self, route: &str, handler: H)
-        where H: Fn(Request, Response, Captures) + Send + Sync + 'static
+    pub fn delete<H>(&mut self, route: &str, handler: H) -> &mut RouterBuilder where 
+        H: Fn(Request, Response, Captures) + Send + Sync + 'static
     {
-        self.add_route(Method::Delete, route, handler);
+        self.route(Method::Delete, route, handler)
     }
 
-    /// A convenience method for PATCH requests.
-    pub fn patch<H>(&mut self, route: &str, handler: H)
-        where H: Fn(Request, Response, Captures) + Send + Sync + 'static
+    pub fn options<H>(&mut self, route: &str, handler: H) -> &mut RouterBuilder where 
+        H: Fn(Request, Response, Captures) + Send + Sync + 'static
     {
-        self.add_route(Method::Patch, route, handler);
+        self.route(Method::Options, route, handler)
     }
 
-    /// This function ensures that a valid `RegexSet` could be made from the route
-    /// vector that was built while using the functions that add routes. It
-    /// requires that there exist at least one route so that the RegexSet can be
-    /// successfully constructed.
-    ///
-    /// It will also ensure that there is a handler for routes that do not match
-    /// any available in the set.
-    pub fn finalize(&mut self) -> Result<(), RouterError> {
-        if self.route_list.is_empty() {
-            return Err(RouterError::TooFewRoutes);
-        }
-
-        // Check if the user added a 404 handler, else use the default.
-        match self.not_found {
-            Some(_) => {}
-            None => {
-                self.not_found = Some(default_not_found);
-            }
-        }
-
-        let re_routes = RegexSet::new(self.route_list.iter());
-        match re_routes {
-            Ok(r) => {
-                self.routes = Some(r);
-                Ok(())
-            }
-            Err(_) => Err(RouterError::BadSet),
-        }
-    }
-
-    /// Add a function to handle routes that get no matches.
-    pub fn add_not_found(&mut self, not_found: NotFoundFn) {
-        self.not_found = Some(not_found)
+    pub fn not_found<H>(&mut self, not_found: H) -> &mut RouterBuilder where
+        H: Fn(Request, Response, Captures) + Send + Sync + 'static
+    {
+        self.not_found = Some(Box::new(not_found));
+        self
     }
 }
 
 // The default 404 handler.
-fn default_not_found(req: Request, mut res: Response) {
+fn default_not_found(req: Request, mut res: Response, _: Captures) {
     let message = format!("No route handler found for {}", req.uri);
     *res.status_mut() = StatusCode::NotFound;
     res.send(message.as_bytes()).unwrap();
@@ -222,20 +163,11 @@ fn get_captures(pattern: &Regex, uri: &str) -> Captures {
     }
 }
 
-mod error;
-
-#[test]
-fn no_routes() {
-    let mut router = Router::new();
-    let e = router.finalize();
-    assert_eq!(e.err(), Some(RouterError::TooFewRoutes));
-}
-
 #[test]
 fn bad_regular_expression() {
     fn test_handler(_: Request, _: Response, _: Captures) {}
-    let mut router = Router::new();
-    router.add_route(Method::Get, r"/[", test_handler);
+    let mut router = RouterBuilder::new();
+    router.route(Method::Get, r"/[", test_handler);
     let e = router.finalize();
-    assert_eq!(e.err(), Some(RouterError::BadSet));
+    assert!(e.is_err());
 }


### PR DESCRIPTION
I have two routes based on different `Regex` strings that can match the same path, but with different methods. Depending on their ordering, current `reroute` forces one to respond with a 405, because it only looks in its route table for the first matching `Regex` string.

(For context, the two routes are `OPTIONS` with `.*$` and `GET` with `/something/specific$`, where the `OPTIONS` route is a generic CORS handler for several other endpoints.)

I don't know that this is the best solution, precedence or performance-wise, but I don't have a lot of experience with other router APIs and how they solve this problem, so I'd like to see what others think here. This PR just loops over all matching `Regex`es rather than failing if the first one's method doesn't match the request.