### PR TITLE
Use a small vector

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,3 +11,5 @@ matrix:
 script:
     - cargo build
     - cargo test
+notifications:
+    email: false

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,6 +12,7 @@ license = "MIT"
 [dependencies]
 hyper = "0.13"
 regex = "1.3"
+smallvec = "1.2"
 
 [dev-dependencies]
 lazy_static = "1.4"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "reroute"
 edition = "2018"
-version = "0.4.0"
+version = "0.4.1"
 authors = ["Garrett Squire <garrettsquire@gmail.com>"]
 description = "A router that can use regular expressions for the hyper package"
 repository = "https://github.com/gsquire/reroute"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -43,7 +43,7 @@ impl Router {
                 continue;
             }
 
-            let ref regex = self.patterns[index];
+            let regex = &self.patterns[index];
             let captures = get_captures(regex, uri);
             return handler(req, captures);
         }
@@ -54,6 +54,7 @@ impl Router {
 
 /// A `RouterBuilder` enables you to build up a set of routes and their handlers
 /// to be handled by a `Router`.
+#[derive(Default)]
 pub struct RouterBuilder {
     routes: Vec<String>,
     handlers: Vec<(Method, RouteHandler)>,
@@ -63,11 +64,7 @@ pub struct RouterBuilder {
 impl RouterBuilder {
     /// Create a new `RouterBuilder` with no route handlers.
     pub fn new() -> RouterBuilder {
-        RouterBuilder {
-            routes: vec![],
-            handlers: vec![],
-            not_found: None,
-        }
+        RouterBuilder::default()
     }
 
     /// Install a handler for requests of method `verb` and which have paths

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,12 +1,13 @@
 use hyper::Method;
 use hyper::{Body, Request, Response, StatusCode};
 use regex::{Regex, RegexSet};
+use smallvec::SmallVec;
 
 pub use error::Error;
 
 mod error;
 
-pub type Captures = Option<Vec<String>>;
+pub type Captures = Option<SmallVec<[String; 4]>>;
 type RouteHandler = Box<dyn Fn(Request<Body>, Captures) -> Response<Body> + Send + Sync>;
 
 /// The Router struct contains the information for your app to route requests
@@ -182,7 +183,7 @@ fn get_captures(pattern: &Regex, uri: &str) -> Captures {
     let caps = pattern.captures(uri);
     match caps {
         Some(caps) => {
-            let mut v = vec![];
+            let mut v = SmallVec::<[String; 4]>::new();
             caps.iter()
                 .filter(|c| c.is_some())
                 .for_each(|c| v.push(c.unwrap().as_str().to_owned()));


### PR DESCRIPTION
This patch tries to avoid some allocations by switching to a `SmallVec` type and using string slices instead of making owned versions of the captures.